### PR TITLE
doc: escape dollar sign in blockquote to avoid broken text rendering

### DIFF
--- a/ToolUse/01_tool_use_overview.ipynb
+++ b/ToolUse/01_tool_use_overview.ipynb
@@ -323,7 +323,7 @@
     "\n",
     "Claude receives the stock price tool result and incorporates the live stock market information into its final response to the original user prompt, finally responding back with something like:\n",
     "\n",
-    ">It looks like with a current share price of $43.09, you can buy around 11 shares of General Motors stock with your $500."
+    ">It looks like with a current share price of \\\\$43.09, you can buy around 11 shares of General Motors stock with your \\\\$500."
    ]
   },
   {


### PR DESCRIPTION
Before the fix (rendered on GitHub):
> It looks like with a current share price of 43.09, youcanbuyaround11sharesof General Motorsstockwithyour500.

After the fix (rendered on GitHub):
> It looks like with a current share price of $43.09, you can buy around 11 shares of General Motors stock with your $500.

I tested the fix in a Notebook and did not observe any regressions.

Note: single or triple backslashes result in invalid JSON, whereas double backslashes causes the same problem.

Thank you for putting this course together.
If I come across any other issues, I'll include them in this PR.

---

Other observations:
- The quiz answers are always visible. It looks like the `<summary>` and `<details>` elements aren't rendered properly here.

If users run the tutorials using Notebook, the issues I brought up earlier probably won't matter. But a lot of people, myself included, would rather read through them on GitHub.