### PR TITLE
docs: fix grammatical error in tool logic description

### DIFF
--- a/ToolUse/01_tool_use_overview.ipynb
+++ b/ToolUse/01_tool_use_overview.ipynb
@@ -106,7 +106,7 @@
     "\n",
     "Let's turn our attention to how tool use actually works. The most important thing to understand up front is that Claude isn't *running* any code on its own.  We tell Claude about a set of tools it can ask us to call, and then it's our job to actually run the underlying tool code and tell Claude about the results. \n",
     "\n",
-    "Note that Claude does not have access to any built-in server-side tools. All tools must be explicitly provided by you, the user, in each API request. This means that you define the available tools, with clear descriptions and input schemas, as well as implements and executes the tool logic, such as running a specific function or querying an API at Claude's request. This gives you full control and flexibility over the tools Claude can use.\n",
+    "Note that Claude does not have access to any built-in server-side tools. All tools must be explicitly provided by you, the user, in each API request. This means that you define the available tools, with clear descriptions and input schemas, as well as implement and execute the tool logic, such as running a specific function or querying an API at Claude's request. This gives you full control and flexibility over the tools Claude can use.\n",
     "\n",
     "![db_tool-2.png](attachment:db_tool-2.png)\n",
     "\n",


### PR DESCRIPTION
Corrected subject-verb agreement error in documentation. Changed "as well as implements and executes the tool logic" to "as well as implement and execute the tool logic."

Before: 
"This means that you define the available tools, with clear descriptions and input schemas, as well as implements and executes the tool logic, such as running a specific function or querying an API at Claude's request."

After: 
"This means that you define the available tools, with clear descriptions and input schemas, as well as implement and execute the tool logic, such as running a specific function or querying an API at Claude's request."