### PR TITLE
docs: fix typo in calculator function description

### DIFF
--- a/ToolUse/02_your_first_simple_tool.ipynb
+++ b/ToolUse/02_your_first_simple_tool.ipynb
@@ -102,7 +102,7 @@
     "\n",
     "![chickens_calculator.png](attachment:chickens_calculator.png)\n",
     "\n",
-    "The first step is to define the actual calculator function and make sure it works, indepent of Claude.  We'll write a VERY simple function that expects three arguments:\n",
+    "The first step is to define the actual calculator function and make sure it works, independent of Claude.  We'll write a VERY simple function that expects three arguments:\n",
     "* An operation like \"add\" or \"multiply\"\n",
     "* Two operands\n",
     "\n",


### PR DESCRIPTION
Corrected a typo in the documentation. Changed "indepent" to "independent" in the description of defining the calculator function.

Before: 
"The first step is to define the actual calculator function and make sure it works, indepent of Claude.  We'll write a VERY simple function that expects three arguments:\n"

After: 
"The first step is to define the actual calculator function and make sure it works, independent of Claude.  We'll write a VERY simple function that expects three arguments:\n"