### PR TITLE
Update 01_getting_started.ipynb

### DIFF
--- a/anthropic_api_fundamentals/01_getting_started.ipynb
+++ b/anthropic_api_fundamentals/01_getting_started.ipynb
@@ -87,7 +87,7 @@
     "\n",
     "Follow these steps to obtain your API key:\n",
     "\n",
-    "1. If you haven't already, sign up for an Anthropic account by visiting https://www.console.anthropic.com \n",
+    "1. If you haven't already, sign up for an Anthropic account by visiting https://console.anthropic.com \n",
     "2. Once you've created your account and logged in, navigate to the API settings page. You can find this page by clicking on your profile icon in the top-right corner and selecting \"API Keys\" from the dropdown menu, or by navigating to the \"API Keys\" menu in the Settings tab.\n",
     "3. On the API settings page, click on the \"Create Key\" button. A modal window will appear, prompting you to give your key a descriptive name. Choose a name that reflects the purpose or project you'll be using the key for. You can create as many keys as you want within your account (note that rate and message limits apply at the account level, not the API key level).\n",
     "4. After entering a name, click on the \"Create\" button. Your new API key will be generated and displayed on the screen.\n",


### PR DESCRIPTION
Removed 'www' subdomain prefix. Otherwise the linked resource does not resolve.

Should be soley: https://console.anthropic.com/.

Regards