### PR TITLE
Update README to include Vertex branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,3 @@ Welcome to Anthropic's educational courses. This repository currently contains f
 
 3. [Real world prompting course](./real_world_prompting/README.md) - learn how to incorporate prompting techniques into complex, real world prompts
 4. [Tool use course](./tool_use/README.md) - teaches everything you need to know to implement tool use successfully in your workflows with Claude.
-

--- a/README.md
+++ b/README.md
@@ -10,4 +10,3 @@ Welcome to Anthropic's educational courses. This repository currently contains f
 3. [Real world prompting course](./real_world_prompting/README.md) - learn how to incorporate prompting techniques into complex, real world prompts
 4. [Tool use course](./tool_use/README.md) - teaches everything you need to know to implement tool use successfully in your workflows with Claude.
 
-[Real world prompting with Google Vertex](https://github.com/anthropics/courses/tree/vertex/real_world_prompting) - learn how to incorporate prompting techniques into complex, real world prompts with Google Vertex 

--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ Welcome to Anthropic's educational courses. This repository currently contains f
 2. [Prompt engineering interactive tutorial](./prompt_engineering_interactive_tutorial/README.md) - a comprehensive step-by-step guide to key prompting techniques
 3. [Real world prompting course](./real_world_prompting/README.md) - learn how to incorporate prompting techniques into complex, real world prompts
 4. [Tool use course](./tool_use/README.md) - teaches everything you need to know to implement tool use successfully in your workflows with Claude.
+
+[Real world prompting with Google Vertex](https://github.com/anthropics/courses/tree/vertex/real_world_prompting) - learn how to incorporate prompting techniques into complex, real world prompts with Google Vertex 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Welcome to Anthropic's educational courses. This repository currently contains f
 
 1. [Anthropic API fundamentals course](./anthropic_api_fundamentals/README.md) - teaches the essentials of working with the Claude SDK: getting an API key, working with model parameters, writing multimodal prompts, streaming responses, etc.
 2. [Prompt engineering interactive tutorial](./prompt_engineering_interactive_tutorial/README.md) - a comprehensive step-by-step guide to key prompting techniques
+
+- [Google Vertex version](https://github.com/anthropics/courses/tree/vertex/real_world_prompting)
+
 3. [Real world prompting course](./real_world_prompting/README.md) - learn how to incorporate prompting techniques into complex, real world prompts
 4. [Tool use course](./tool_use/README.md) - teaches everything you need to know to implement tool use successfully in your workflows with Claude.
 


### PR DESCRIPTION
Added a link in the readme on `master` to the `vertex` branch which includes the prompting course all in Vertex