### PR TITLE
Nitpick: updated tool use text to be consistent

### DIFF
--- a/tool_use/04_complete_workflow.ipynb
+++ b/tool_use/04_complete_workflow.ipynb
@@ -268,16 +268,16 @@
    "source": [
     "Claude's response contains 2 blocks: \n",
     "\n",
-    "* A TextBlock with the text \"Okay, let me use the available tool to try and find information on who won the 2024 Masters Tournament on Wikipedia:\"\n",
+    "* A TextBlock with the text \"Okay, let me see if I can find information about the winner of the 2024 Masters Tournament on Wikipedia:\"\n",
     "\n",
     "```\n",
-    "TextBlock(text='Okay, let me use the available tool to try and find information on who won the 2024 Masters Tournament:', type='text')\n",
+    "TextBlock(text='Okay, let me see if I can find information about the winner of the 2024 Masters Tournament on Wikipedia:', type='text')\n",
     "```\n",
     "\n",
     "* A ToolUseBlock calling our `get_article` tool with the `search_term` \"2024 Masters Tournament\"\n",
     "\n",
     "```\n",
-    "ToolUseBlock(id='toolu_01MbstBxD654o9hE2RGNdtSr', input={'search_term': '2024 Masters Tournament'}, name='get_article', type='tool_use')]\n",
+    "ToolUseBlock(id='toolu_01CWuduGjgSRfsYJUNC2wxi7', input={'search_term': '2024 Masters Tournament'}, name='get_article', type='tool_use')]\n",
     "```\n"
    ]
   },


### PR DESCRIPTION
Non Urgent Nitpick: I'm enjoying the Tool Use courses and noticed there's some text inconsistency on a text description. The blue and purple regions are referring to the same tool use but have different text.

![image](https://github.com/user-attachments/assets/3ca5f81c-9eb9-4c11-b0fe-448f1c285a59)
