### PR TITLE
Add pickleshare to required dependencies

### DIFF
--- a/prompt_engineering_interactive_tutorial/Anthropic 1P/00_Tutorial_How-To.ipynb
+++ b/prompt_engineering_interactive_tutorial/Anthropic 1P/00_Tutorial_How-To.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "1. Clone this repository to your local machine.\n",
     "\n",
-    "2. Install the required dependencies by running the following command:\n",
+    "2. Install the required dependencies by running the following commands:\n",
     " "
    ]
   },
@@ -27,7 +27,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install anthropic"
+    "%pip install anthropic\n",
+    "%pip install pickleshare"
    ]
   },
   {


### PR DESCRIPTION
Fixes https://github.com/anthropics/courses/issues/46

In recent versions of IPython, `pickleshare` is required for users to be able to store and fetch `API_KEY` and `MODEL_NAME` across notebooks.