### PR TITLE
Fix incorrect arguments and resulting prompts in prompts.py files for lessons 5, 6, and 9 of prompt_evaluations course

### DIFF
--- a/prompt_evaluations/05_prompt_foo_code_graded_animals/prompts.py
+++ b/prompt_evaluations/05_prompt_foo_code_graded_animals/prompts.py
@@ -1,26 +1,29 @@
-def simple_prompt(animal_statement):
+def simple_prompt(context: dict):
+    variables = context['vars']
     return f"""You will be provided a statement about an animal and your job is to determine how many legs that animal has.
     
-    Here is the animal statement.
-    <animal_statement>{animal_statement}</animal_statement>
-    
-    How many legs does the animal have? Please respond with a number"""
+Here is the animal statement.
+<animal_statement>{variables['animal_statement']}</animal_statement>
 
-def better_prompt(animal_statement):
-    return f"""You will be provided a statement about an animal and your job is to determine how many legs that animal has.
-    
-    Here is the animal statement.
-    <animal_statement>{animal_statement}</animal_statement>
-    
-    How many legs does the animal have? Please only respond with a single digit like 2 or 9"""
+How many legs does the animal have? Please respond with a number"""
 
-def chain_of_thought_prompt(animal_statement):
+def better_prompt(context: dict):
+    variables = context['vars']
     return f"""You will be provided a statement about an animal and your job is to determine how many legs that animal has.
     
-    Here is the animal statement.
-    <animal_statement>{animal_statement}</animal_statement>
+Here is the animal statement.
+<animal_statement>{variables['animal_statement']}</animal_statement>
+
+How many legs does the animal have? Please only respond with a single digit like 2 or 9"""
+
+def chain_of_thought_prompt(context: dict):
+    variables = context['vars']
+    return f"""You will be provided a statement about an animal and your job is to determine how many legs that animal has.
     
-    How many legs does the animal have? 
-    Start by reasoning about the numbers of legs the animal has, thinking step by step inside of <thinking> tags.  
-    Then, output your final answer inside of <answer> tags. 
-    Inside the <answer> tags return just the number of legs as an integer and nothing else."""
+Here is the animal statement.
+<animal_statement>{variables['animal_statement']}</animal_statement>
+
+How many legs does the animal have? 
+Start by reasoning about the numbers of legs the animal has, thinking step by step inside of <thinking> tags.  
+Then, output your final answer inside of <answer> tags. 
+Inside the <answer> tags return just the number of legs as an integer and nothing else."""

--- a/prompt_evaluations/06_prompt_foo_code_graded_classification/prompts.py
+++ b/prompt_evaluations/06_prompt_foo_code_graded_classification/prompts.py
@@ -1,60 +1,62 @@
-def basic_prompt(complaint):
-    return f"""
-    Classify the following customer complaint into one or more of these categories: 
-    Software Bug, Hardware Malfunction, User Error, Feature Request, or Service Outage.
-    Only respond with the classification.
+def basic_prompt(context: dict):
+    variables = context['vars']
+    return f"""\
+Classify the following customer complaint into one or more of these categories: 
+Software Bug, Hardware Malfunction, User Error, Feature Request, or Service Outage.
+Only respond with the classification.
 
-    Complaint: {complaint}
+Complaint: {variables['complaint']}
 
-    Classification:
-    """
+Classification:
+"""
 
 
-def improved_prompt(complaint):
-    return f"""
-    You are an AI assistant specializing in customer support issue classification. Your task is to analyze customer complaints and categorize them into one or more of the following categories:
+def improved_prompt(context: dict):
+    variables = context['vars']
+    return f"""\
+You are an AI assistant specializing in customer support issue classification. Your task is to analyze customer complaints and categorize them into one or more of the following categories:
 
-    1. Software Bug: Issues related to software not functioning as intended.
-    2. Hardware Malfunction: Problems with physical devices or components.
-    3. User Error: Difficulties arising from user misunderstanding or misuse.
-    4. Feature Request: Suggestions for new functionalities or improvements.
-    5. Service Outage: System-wide issues affecting service availability.
+1. Software Bug: Issues related to software not functioning as intended.
+2. Hardware Malfunction: Problems with physical devices or components.
+3. User Error: Difficulties arising from user misunderstanding or misuse.
+4. Feature Request: Suggestions for new functionalities or improvements.
+5. Service Outage: System-wide issues affecting service availability.
 
-    Important Guidelines:
-    - A complaint may fall into multiple categories. If so, list all that apply but try to prioritize picking a single category when possible.
+Important Guidelines:
+- A complaint may fall into multiple categories. If so, list all that apply but try to prioritize picking a single category when possible.
 
-    Examples:
-    1. Complaint: "The app crashes when I try to save my progress."
-    Classification: Software Bug
+Examples:
+1. Complaint: "The app crashes when I try to save my progress."
+Classification: Software Bug
 
-    2. Complaint: "My keyboard isn't working after I spilled coffee on it."
-    Classification: Hardware Malfunction
+2. Complaint: "My keyboard isn't working after I spilled coffee on it."
+Classification: Hardware Malfunction
 
-    3. Complaint: "I can't find the login button on your website."
-    Classification: User Error
+3. Complaint: "I can't find the login button on your website."
+Classification: User Error
 
-    4. Complaint: "It would be great if your app had a dark mode."
-    Classification: Feature Request
+4. Complaint: "It would be great if your app had a dark mode."
+Classification: Feature Request
 
-    5. Complaint: "None of your services are loading for me or my colleagues."
-    Classification: Service Outage
+5. Complaint: "None of your services are loading for me or my colleagues."
+Classification: Service Outage
 
-    6. Complaint "Complaint: The app breaks every time I try to change my profile picture"
-    Classification: Software Bug
+6. Complaint "Complaint: The app breaks every time I try to change my profile picture"
+Classification: Software Bug
 
-    7. Complaint "The app is acting buggy on my phone and it seems like your website is down, so I'm completely stuck!"
-    Classification: Software Bug, Service Outage
+7. Complaint "The app is acting buggy on my phone and it seems like your website is down, so I'm completely stuck!"
+Classification: Software Bug, Service Outage
 
-    8. Complaint: "Your software makes my computer super laggy and awful, I hate it!"
-    Classification: Software Bug
+8. Complaint: "Your software makes my computer super laggy and awful, I hate it!"
+Classification: Software Bug
 
-    9. Complaint: "Your dumb app always breaks when I try to do anything with images."
-    Classification: 'Software Bug'
+9. Complaint: "Your dumb app always breaks when I try to do anything with images."
+Classification: 'Software Bug'
 
-    Now, please classify the following customer complaint:
+Now, please classify the following customer complaint:
 
-    <complaint>{complaint}</complaint>
+<complaint>{variables['complaint']}</complaint>
 
-    Only respond with the appropriate categories and nothing else.
-    Classification:
-    """
+Only respond with the appropriate categories and nothing else.
+Classification:
+"""

--- a/prompt_evaluations/09_custom_model_graded_prompt_foo/prompts.py
+++ b/prompt_evaluations/09_custom_model_graded_prompt_foo/prompts.py
@@ -1,14 +1,16 @@
-def basic_summarize(article):
-  return f"Summarize this article {article}"
+def basic_summarize(context: dict):
+  variables = context['vars']
+  return f"Summarize this article {variables['article']}"
 
-def better_summarize(article):
-  return f"""
-  Summarize this article for a grade-school audience: {article}"""
+def better_summarize(context: dict):
+  variables = context['vars']
+  return f"""Summarize this article for a grade-school audience: {variables['article']}"""
 
-def best_summarize(article):
-  return f"""
-  You are tasked with summarizing long wikipedia articles for a grade-school audience.
-  Write a short summary, keeping it as concise as possible. 
-  The summary is intended for a non-technical, grade-school audience. 
-  This is the article: {article}"""
+def best_summarize(context: dict):
+  variables = context['vars']
+  return f"""\
+You are tasked with summarizing long wikipedia articles for a grade-school audience.
+Write a short summary, keeping it as concise as possible. 
+The summary is intended for a non-technical, grade-school audience. 
+This is the article: {variables['article']}"""
 


### PR DESCRIPTION
In the prompt evaluations course, lessons 5, 6, and 9 use a prompts.py file to have promptfoo compose the prompts. However, the existing versions incorrectly assume that the needed variable is directly passed; instead, promptfoo passes a context dict with a 'vars' key, from which the desired variable can be extracted. This affects the prompts passed to the models and the resulting eval scores. The prompt that is actually passed can be seen by clicking on the magnifying glass in any of the cells in the promptfoo viewer. This is a somewhat insidious error, given that everything runs and one wouldn't notice unless drilling down to see the actual final prompts passed to the models.

In lesson 5, by my runs, Haiku goes from 0% passing with the simple_prompt, to 75% passing after the fix, and from 66.67% passing to 75% passing with the better_prompt after the fix. There are changes in eval metrics in lessons 6 and 9 as well after fixing the prompts, albeit less dramatic than for lesson 5. For lesson 5, the new outcomes would require a small change to the narrative in the notebook (happy to do this, but I assumed you'd prefer someone at Anthropic make those changes) and perhaps to the simple_prompt. 