### PR TITLE
Typo: Fix `with` Typo in API Fundamentals

### DIFF
--- a/anthropic_api_fundamentals/02_messages_format.ipynb
+++ b/anthropic_api_fundamentals/02_messages_format.ipynb
@@ -13,7 +13,7 @@
    "source": [
     "## Lesson goals\n",
     "- Understand the messages API format\n",
-    "- Work wit and understand model response objects\n",
+    "- Work with and understand model response objects\n",
     "- Build a simple multi-turn chatbot"
    ]
   },


### PR DESCRIPTION
This commit fixes a typo from `wit` to `with` in the "Lesson Goals" section of the "02 Messages Format" lesson of the API Fundamentals" course.